### PR TITLE
add whitelisted link wrappers list

### DIFF
--- a/dist/src/content.js
+++ b/dist/src/content.js
@@ -1,13 +1,17 @@
 const REFLECT_INFO = '#576ca8';
 const REFLECT_ERR = '#ff4a47';
+const WHITELISTED_WRAPPERS = [
+    'facebook.com/flx',
+    'l.facebook.com',
+];
 chrome.storage.sync.get(null, (storage) => {
     // check to see if reflect is enabled
     if (storage.isEnabled) {
         // check for is blocked
         const strippedURL = getStrippedUrl();
         storage.blockedSites.forEach((site) => {
-            // is blocked
-            if (strippedURL.includes(site)) {
+            // is blocked and not a whitelisted wrapper
+            if (strippedURL.includes(site) && !isWhitelistedWrapper()) {
                 iterWhitelist();
             }
         });
@@ -19,6 +23,10 @@ function displayStatus(message, duration = 3000, colour = REFLECT_INFO) {
     $('#statusContent').text(message);
     // show, wait, then hide
     $('#statusContent').show().delay(duration).fadeOut();
+}
+function isWhitelistedWrapper() {
+    // check if any wrapper urls are present in current url
+    return WHITELISTED_WRAPPERS.some((wrapper) => window.location.href.includes(wrapper));
 }
 function getStrippedUrl() {
     // match url

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,14 +1,17 @@
-const REFLECT_INFO = '#576ca8'
-const REFLECT_ERR = '#ff4a47'
+const REFLECT_INFO: string = '#576ca8'
+const REFLECT_ERR: string = '#ff4a47'
+
+const WHITELISTED_WRAPPERS: string[] = ['facebook.com/flx', 'l.facebook.com']
 
 chrome.storage.sync.get(null, (storage) => {
     // check to see if reflect is enabled
     if (storage.isEnabled) {
         // check for is blocked
+
         const strippedURL: string = getStrippedUrl()
         storage.blockedSites.forEach((site: string) => {
-            // is blocked
-            if (strippedURL.includes(site)) {
+            // is blocked and not a whitelisted wrapper
+            if (strippedURL.includes(site) && !isWhitelistedWrapper()) {
                 iterWhitelist()
             }
         })
@@ -26,6 +29,11 @@ function displayStatus(
 
     // show, wait, then hide
     $('#statusContent').show().delay(duration).fadeOut()
+}
+
+function isWhitelistedWrapper(): boolean {
+    // check if any wrapper urls are present in current url
+    return WHITELISTED_WRAPPERS.some((wrapper) => window.location.href.includes(wrapper))
 }
 
 function getStrippedUrl(): string {


### PR DESCRIPTION
Closes #62 

Turns out browser handles 301 and 302 redirects before even loading content so the only time that these redirects have trouble is when clicking on link wrappers.

This PR adds a list of common link wrappers to whitelist (not block). Might want to include option to customize this list in the future