### PR TITLE
- Fixed https://github.com/getreflect/reflect-chrome/issues/122

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -44,8 +44,7 @@ function checkIfBlocked(): void {
       // if google.com is blocked, meet.google.com includes .google.com --> meet.google.com is not blocked
       // conversely if meet.google.com is blocked, google.com does not include meet.google.com --> google.com is not blocked
       if (
-        ((!strippedURL.includes(`.${site}`) && strippedURL.includes(site)) ||
-          exactURL.includes(site)) &&
+        ((!strippedURL.includes(`.${site}`) && strippedURL.includes(site)) || exactURL === site) &&
         !isWhitelistedWrapper()
       ) {
         // found a match, check if currently on whitelist


### PR DESCRIPTION
Hi there!
I've looked through your code and found out that you've already implemented it, but had a bug in implementation.

In content.ts/checkIfBlocked

There is a comment and condition:
// if google.com is blocked, meet.google.com includes .google.com --> meet.google.com is not blocked // conversely if meet.google.com is blocked, google.com does not include meet.google.com --> google.com is not blocked if ( ((!strippedURL.includes(.${site}) && strippedURL.includes(site)) || exactURL.includes(site)) && !isWhitelistedWrapper() )
The first part of condition does what you described in the comment. But the second one (for exactURL) - effectivly destroys.
It seems that you wanted to do
exactURL === site instead of exactURL.includes(site)

I've just fixed it and made a pull request for you.